### PR TITLE
rc file!

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+** 05/08/2014 , v0.9.4 **
+	- kaplot.defaults also imports any settings defined in ~/.kaplotdefaults.rc transparently.
+
 ** 04/28/2014 , v0.9.3 **
 	- kaplot initization optionally takes settings as list
 	- Addition of `markers` default which produces plots with only markers

--- a/kaplot/__init__.py
+++ b/kaplot/__init__.py
@@ -25,7 +25,7 @@ from scipy.interpolate import UnivariateSpline
 from numpy import linspace
 
 __author__		= 'Kamil'
-__version__		= '0.9.3'
+__version__		= '0.9.4'
 __name__		= 'kaplot'
 
 @decorator

--- a/kaplot/defaults.py
+++ b/kaplot/defaults.py
@@ -2,7 +2,12 @@
 Defines a couple of default settings dictionaries for importing into a kaplot object.
 They are user overwritable, by passing a custom dictionary (or list of of dicts) to the kaplot `__init__` function.
 Any parameters not specified by the user will come from the `default` settings dictionary.
+
+If it exists, import any user-defined settings from ~/.kaplotdefaults.rc
 """
+
+from imp import load_source
+from os.path import expanduser
 
 default = {
 	'PLOT_SETTINGS' 	:	{	'tight_layout'	:	False 		, \
@@ -257,3 +262,12 @@ bw = blackandwhite
 markers = {
 	'_MARKER_LIST' 		:	['s' , 'o' , '^' , 'D'],
 }
+
+try:
+	kud = load_source('kaplotUserDefaults',expanduser('~/.kaplotdefaults.rc'))
+	for key,value in kud.__dict__.iteritems():
+		if key.startswith('__'):
+			continue
+		globals()[key] = value
+except IOError:
+	pass


### PR DESCRIPTION
So you can have a file at `~/.kaplotdefaults.rc` now. When you import `kaplot.defaults` from system, anything in there will be transparently added in. e.g.:

```
**.kaplotdefaults.rc**
settingname = {...}
```

then in your script, you can do

```
>>> from kaplot.defaults import settingname
>>> settingname
{...}
```
