### PR TITLE
strings in settings

### DIFF
--- a/kaplot/__init__.py
+++ b/kaplot/__init__.py
@@ -26,7 +26,7 @@ from scipy.interpolate import UnivariateSpline
 from numpy import linspace
 
 __author__		= 'Kamil'
-__version__		= '0.9.5'
+__version__		= '1.0.0~beta1'
 __name__		= 'kaplot'
 
 @decorator


### PR DESCRIPTION
- `settings` can now accept strings as an argument. It'll look up in `kaplot.defaults` (and the rc file).
- Version bump to 1.0.0 beta1.
